### PR TITLE
minor fix for running inference.py on cpu

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -117,7 +117,7 @@ def main(args):
                 'to', 'under', 'using', 'walking in', 'walking on', 'watching', 'wearing', 'wears', 'with']
 
     model, _, _ = build_model(args)
-    ckpt = torch.load(args.resume)
+    ckpt = torch.load(args.resume, map_location=torch.device('cpu')) if args.device == "cpu" else torch.load(args.resume)
     model.load_state_dict(ckpt['model'])
     model.eval()
 


### PR DESCRIPTION
It seems like map_location=torch.device('cpu') should be passed to torch.load when using cpu.